### PR TITLE
Added a Linkwitz-Riley filter (48 dB/octave) before the I2S audio out…

### DIFF
--- a/Audio.h
+++ b/Audio.h
@@ -68,4 +68,5 @@
 #include "synth_pinknoise.h"
 #include "Oscilloscope.h"
 #include "analyze_peak.h"
+#include "filter_biquad.h"
 #endif

--- a/AudioPatching.h
+++ b/AudioPatching.h
@@ -114,6 +114,8 @@ AudioMixer4              effectMixerR;         //xy=1848,625
 AudioMixer4              effectMixerL;         //xy=1857,539
 AudioOutputI2S           i2s;            //xy=2364,547
 AudioOutputUSB           usbAudio;       //xy=2356,593
+AudioFilterBiquad        lrfilterR;      //xy=2356,593
+AudioFilterBiquad        lrfilterL;      //xy=2356,593
 AudioConnection          patchCord1(constant1Dc, filterEnvelope2);
 AudioConnection          patchCord2(constant1Dc, filterEnvelope3);
 AudioConnection          patchCord3(constant1Dc, filterEnvelope4);
@@ -241,8 +243,8 @@ AudioConnection          patchCord114(ensemble, 1, effectMixerR, 1);
 AudioConnection          patchCord115(volumeMixer, 0, effectMixerL, 0);
 AudioConnection          patchCord116(volumeMixer, 0, effectMixerR, 0);
 AudioConnection          patchCord117(effectMixerR, 0, usbAudio, 1);
-AudioConnection          patchCord118(effectMixerR, 0, i2s, 1);
-AudioConnection          patchCord119(effectMixerL, 0, i2s, 0);
+AudioConnection          patchCord118(effectMixerR, 0, lrfilterL, 0);
+AudioConnection          patchCord119(effectMixerL, 0, lrfilterR, 0);
 AudioConnection          patchCord120(effectMixerL, 0, usbAudio, 0);
 AudioConnection          patchCord121(oscModMixer1a, 0, waveformMod1a, 0);
 AudioConnection          patchCord122(oscModMixer1b, 0, waveformMod1b, 0);
@@ -331,5 +333,7 @@ AudioConnection          patchCord200(constant1Dc, filterEnvelope6);
 AudioConnection          patchCord203(voiceMixerM, 0, dcOffsetFilter, 0);
 AudioConnection          patchCord217(dcOffsetFilter, 2, volumeMixer, 0);
 AudioConnection          patchCord216(dcOffsetFilter, 2, peak, 0);
+AudioConnection          patchCord218(lrfilterL, 0, i2s, 1);
+AudioConnection          patchCord219(lrfilterR, 0, i2s, 0);
 AudioControlSGTL5000     sgtl5000_1;     //xy=2353,505
 // GUItool: end automatically generated code

--- a/TSynth.ino
+++ b/TSynth.ino
@@ -83,6 +83,8 @@ unsigned int state = PARAMETER;
 #define WAVEFORM_PARABOLIC 103
 #define WAVEFORM_HARMONIC 104
 
+#define LR_FILTER_CUTOFF_HZ 7500
+
 struct VoiceAndNote {
   int note;
   long timeOn;
@@ -353,6 +355,16 @@ void setup()
 
   //Read VU enable from EEPROM
   vuMeter = getVUEnable();
+
+  // Linkwitz-Riley filter, 48 dB/octave
+  lrfilterR.setLowpass(0, LR_FILTER_CUTOFF_HZ, 0.54);
+  lrfilterR.setLowpass(1, LR_FILTER_CUTOFF_HZ, 1.3);
+  lrfilterR.setLowpass(2, LR_FILTER_CUTOFF_HZ, 0.54);
+  lrfilterR.setLowpass(3, LR_FILTER_CUTOFF_HZ, 1.3);
+  lrfilterL.setLowpass(0, LR_FILTER_CUTOFF_HZ, 0.54);
+  lrfilterL.setLowpass(1, LR_FILTER_CUTOFF_HZ, 1.3);
+  lrfilterL.setLowpass(2, LR_FILTER_CUTOFF_HZ, 0.54);
+  lrfilterL.setLowpass(3, LR_FILTER_CUTOFF_HZ, 1.3);
 }
 
 void myNoteOn(byte channel, byte note, byte velocity)


### PR DESCRIPTION
…put for trying to limit aliasing.

Perhaps you want to try this. I am not sure if this helps... maybe the cutoff frequency has to be setup in the "Settings" menu.